### PR TITLE
送信メッセージの弁当の並べ方を変更する

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,12 +405,16 @@
                     normalSizeSum += normalSize;
                     bigSizeSum += bigSize;
 
-                    values.push(`${name} 大盛 ${bigSize}個 普通 ${normalSize}個`);
+                    values.push(name);
+                    values.push(`大盛 ${bigSize}個 普通 ${normalSize}個`);
                 });
 
-                const sum = `合計 大盛 ${bigSizeSum}個 普通 ${normalSizeSum}個`;
+                const sum = `大盛 ${bigSizeSum}個 普通 ${normalSizeSum}個`;
 
-                return [...values, sum];
+                values.push('合計');
+                values.push(sum);
+
+                return values;
             };
 
             const createMessage = () => {

--- a/index.html
+++ b/index.html
@@ -399,15 +399,18 @@
                 let bigSizeSum = 0;
 
                 $('#menu > div.input-area').each(function () {
+                    const name = $('.item-name', this).text();
                     const normalSize = Number($('input.normal-size', this).val()) || 0;
                     const bigSize = Number($('input.big-size', this).val()) || 0;
                     normalSizeSum += normalSize;
                     bigSizeSum += bigSize;
 
-                    values.push(bigSize, normalSize);
+                    values.push(`${name} 大盛 ${bigSize}個 普通 ${normalSize}個`);
                 });
 
-                return [...values, bigSizeSum, normalSizeSum];
+                const sum = `合計 大盛 ${bigSizeSum}個 普通 ${normalSizeSum}個`;
+
+                return [...values, sum];
             };
 
             const createMessage = () => {

--- a/index.html
+++ b/index.html
@@ -406,10 +406,10 @@
                     bigSizeSum += bigSize;
 
                     values.push(name);
-                    values.push(`大盛 ${bigSize}個 普通 ${normalSize}個`);
+                    values.push(`普通 ${normalSize}個 大盛 ${bigSize}個`);
                 });
 
-                const sum = `大盛 ${bigSizeSum}個 普通 ${normalSizeSum}個`;
+                const sum = `普通 ${normalSizeSum}個 大盛 ${bigSizeSum}個`;
 
                 values.push('合計');
                 values.push(sum);


### PR DESCRIPTION
#16 の修正

送信メッセージの弁当の並べ方を以下のようにしました。

```
さわらだし焼き弁当 大盛 2個 普通 1個
鶏ももからあげ弁当 大盛 4個 普通 3個
ハンバーグ弁当 大盛 6個 普通 5個
サバ塩麹焼き弁当 大盛 8個 普通 7個
かに玉弁当 大盛 10個 普通 9個
からあげカレー弁当 大盛 12個 普通 11個
日替わり弁当 大盛 14個 普通 13個
合計 大盛 56個 普通 49個
```